### PR TITLE
Make importing URLs from installed apps work.

### DIFF
--- a/django_autoconfig/autourlconf.py
+++ b/django_autoconfig/autourlconf.py
@@ -1,6 +1,7 @@
 '''This module can be set as a ROOT_URLCONF (or included into one).'''
 
 from django.conf import settings
+from django.utils.importlib import import_module
 from django.conf.urls import include, patterns, url
 
 from .app_settings import AUTOCONFIG_EXTRA_URLS
@@ -9,12 +10,8 @@ urlpatterns = patterns('')
 
 for app_name in list(settings.INSTALLED_APPS) + list(AUTOCONFIG_EXTRA_URLS):
     try:
-        urlpatterns += patterns(
-            '',
-            url(
-                r'^%s/' % app_name.replace("_","-"),
-                include("%s.urls" % app_name),
-            ),
-        )
+        app_urls = import_module(app_name + '.urls')
+        urlpatterns += app_urls.urlpatterns
     except ImportError:
         pass
+


### PR DESCRIPTION
Hi,

I couldn't see how this used to work?

For example, with django.contrib.auth in installed_apps, the relevant configured URLs were:

```
^django.contrib.auth/
```

Whereas with this patch applied, they look like this:

```
^login/$ [name='login'] 
^logout/$ [name='logout'] 
^password_change/$ [name='password_change'] 
^password_change/done/$ [name='password_change_done'] 
^password_reset/$ [name='password_reset'] 
^password_reset/done/$ [name='password_reset_done'] 
^reset/(?P<uidb36>[0-9A-Za-z]{1,13})-(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$ [name='password_reset_confirm'] 
^reset/done/$ [name='password_reset_complete']
```

Not sure what original functionality this patch breaks, so will need review!
