### PR TITLE
Django 1.10 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+pep8.txt
+coverage.xml
 
 # Translations
 *.mo

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ matrix:
     env: DJANGO=1.4.15
   - python: 3.5
     env: DJANGO=1.4.15
+  - python: 3.5
+    env: DJANGO=1.6.7
+  - python: 3.5
+    env: DJANGO=1.7
   - python: pypy3
     env: DJANGO=1.4.15
   - python: pypy3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
 - 2.6
 - 2.7
 - 3.3
+- 3.4
+- 3.5
 - pypy
 - pypy3
 env:
@@ -11,6 +13,7 @@ env:
 - DJANGO=1.7
 - DJANGO=1.8
 - DJANGO=1.9
+- DJANGO=1.10
 install:
 - pip install -q gitversion
 - pip install -q Django==$DJANGO
@@ -26,14 +29,22 @@ matrix:
     env: DJANGO=1.7
   - python: 2.6
     env: DJANGO=1.8
+  - python: 2.6
+    env: DJANGO=1.9
+  - python: 2.6
+    env: DJANGO=1.10
   - python: 3.3
+    env: DJANGO=1.4.15
+  - python: 3.3
+    env: DJANGO=1.9
+  - python: 3.3
+    env: DJANGO=1.10
+  - python: 3.4
+    env: DJANGO=1.4.15
+  - python: 3.5
     env: DJANGO=1.4.15
   - python: pypy3
     env: DJANGO=1.4.15
-  - python: 2.6
-    env: DJANGO=1.9
-  - python: 3.3
-    env: DJANGO=1.9
   - python: pypy3
     env: DJANGO=1.9
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ matrix:
     env: DJANGO=1.4.15
   - python: pypy3
     env: DJANGO=1.9
+  - python: pypy3
+    env: DJANGO=1.10
 deploy:
   provider: pypi
   user: LeaChim

--- a/django_autoconfig/autoconfig.py
+++ b/django_autoconfig/autoconfig.py
@@ -4,7 +4,12 @@ import collections
 import copy
 from django.core.exceptions import ImproperlyConfigured
 from django.conf import global_settings
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
+try:
+    from django.conf.urls import patterns
+except ImportError:
+    def patterns(_, *args):
+        return args
 from django.utils.functional import Promise
 from django.utils.module_loading import module_has_submodule
 import imp

--- a/django_autoconfig/contrib/admin/urls.py
+++ b/django_autoconfig/contrib/admin/urls.py
@@ -1,4 +1,9 @@
-from django.conf.urls import patterns, include
+from django.conf.urls import include
+try:
+    from django.conf.urls import patterns
+except ImportError:
+    def patterns(_, *args):
+        return args
 from django.contrib import admin
 
 admin.autodiscover()

--- a/django_autoconfig/tests/app_urls/urls.py
+++ b/django_autoconfig/tests/app_urls/urls.py
@@ -1,5 +1,12 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
+try:
+    from django.conf.urls import patterns
+except ImportError:
+    def patterns(_, *args):
+        return args
+
+from django_autoconfig.tests.app_urls.views import index
 
 urlpatterns = patterns('',
-    url(r'^index/$', 'django_autoconfig.tests.app_urls.views.index'),
+    url(r'^index/$', index),
 )

--- a/django_autoconfig/tests/test_autoconfig.py
+++ b/django_autoconfig/tests/test_autoconfig.py
@@ -303,7 +303,8 @@ class IndexViewTestCase(test.TestCase):
     '''Test the index view.'''
     urls = 'django_autoconfig.tests.index_view_urlconf'
 
-    @unittest.skipIf(django.VERSION < (1, 6), 'AUTOCONFIG_INDEX_VIEW needs Django >= 1.6')
+    @unittest.skipIf(django.VERSION < (1, 6) or django.VERSION > (1, 9),
+                     'AUTOCONFIG_INDEX_VIEW needs Django >= 1.6, < 1.10')
     def test_index_view(self):
         '''Test the index view functionality.'''
         response = self.client.get('/')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from django_autoconfig.version import __VERSION__
 import sys
 
 INSTALL_REQUIRES = [
-    'django < 1.10',
+    'django < 1.11',
 ]
 
 if sys.version_info < (2, 7):
@@ -34,7 +34,8 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ],
 )


### PR DESCRIPTION
refs #32
- Update urlpatterns to lists of `urls()` instead of using `patterns()`
- Add Python 3.4 and 3.5 to the build matrix
- Skip undocumented `AUTOCONFIG_INDEX_VIEW` for Django 1.10 as it's now [much harder](https://docs.djangoproject.com/en/1.10/releases/1.10/) to do.
