### PR TITLE
Django 1.10 compatability

### DIFF
--- a/django_autoconfig/contrib/__init__.py
+++ b/django_autoconfig/contrib/__init__.py
@@ -13,14 +13,14 @@ CONTRIB_CONFIGS = {
                 'django.contrib.contenttypes',
                 'django.contrib.sessions',
             ],
-            'MIDDLEWARE_CLASSES': [
+            'MIDDLEWARE': [
                 'django.contrib.auth.middleware.AuthenticationMiddleware',
             ],
         },
         DEFAULT_SETTINGS = {},
         RELATIONSHIPS = [
             OrderingRelationship(
-                'MIDDLEWARE_CLASSES',
+                'MIDDLEWARE',
                 'django.contrib.auth.middleware.AuthenticationMiddleware',
                 after = [
                     'django.middleware.common.CommonMiddleware',
@@ -36,7 +36,7 @@ CONTRIB_CONFIGS = {
             'INSTALLED_APPS': [
                 'django.contrib.sessions',
             ],
-            'MIDDLEWARE_CLASSES': [
+            'MIDDLEWARE': [
                 'django.contrib.messages.middleware.MessageMiddleware',
             ],
             'TEMPLATE_CONTEXT_PROCESSORS': [
@@ -56,7 +56,7 @@ CONTRIB_CONFIGS = {
         DEFAULT_SETTINGS = {},
         RELATIONSHIPS = [
             OrderingRelationship(
-                'MIDDLEWARE_CLASSES',
+                'MIDDLEWARE',
                 'django.contrib.messages.middleware.MessageMiddleware',
                 after = [
                     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -68,14 +68,14 @@ CONTRIB_CONFIGS = {
     ),
     'django.contrib.sessions': Autoconfig(
         SETTINGS = {
-            'MIDDLEWARE_CLASSES': [
+            'MIDDLEWARE': [
                 'django.contrib.sessions.middleware.SessionMiddleware',
             ],
         },
         DEFAULT_SETTINGS = {},
         RELATIONSHIPS = [
             OrderingRelationship(
-                'MIDDLEWARE_CLASSES',
+                'MIDDLEWARE',
                 'django.contrib.sessions.middleware.SessionMiddleware',
                 after = [
                     'django.middleware.cache.UpdateCacheMiddleware',

--- a/django_autoconfig/contrib/__init__.py
+++ b/django_autoconfig/contrib/__init__.py
@@ -1,7 +1,6 @@
 '''Autoconfig data for applications that don't support this protocol.'''
 
 from collections import namedtuple
-from distutils.version import StrictVersion
 import django
 from django_autoconfig.autoconfig import OrderingRelationship
 

--- a/django_autoconfig/contrib/__init__.py
+++ b/django_autoconfig/contrib/__init__.py
@@ -1,10 +1,15 @@
 '''Autoconfig data for applications that don't support this protocol.'''
 
 from collections import namedtuple
-
+from distutils.version import StrictVersion
+import django
 from django_autoconfig.autoconfig import OrderingRelationship
 
 Autoconfig = namedtuple('Autoconfig', ('SETTINGS', 'DEFAULT_SETTINGS', 'RELATIONSHIPS'))
+if django.VERSION < (1, 10):
+    middleware_key = 'MIDDLEWARE_CLASSES'
+else:
+    middleware_key = 'MIDDLEWARE'
 
 CONTRIB_CONFIGS = {
     'django.contrib.auth': Autoconfig(
@@ -13,14 +18,14 @@ CONTRIB_CONFIGS = {
                 'django.contrib.contenttypes',
                 'django.contrib.sessions',
             ],
-            'MIDDLEWARE': [
+            middleware_key: [
                 'django.contrib.auth.middleware.AuthenticationMiddleware',
             ],
         },
         DEFAULT_SETTINGS = {},
         RELATIONSHIPS = [
             OrderingRelationship(
-                'MIDDLEWARE',
+                middleware_key,
                 'django.contrib.auth.middleware.AuthenticationMiddleware',
                 after = [
                     'django.middleware.common.CommonMiddleware',
@@ -36,7 +41,7 @@ CONTRIB_CONFIGS = {
             'INSTALLED_APPS': [
                 'django.contrib.sessions',
             ],
-            'MIDDLEWARE': [
+            middleware_key: [
                 'django.contrib.messages.middleware.MessageMiddleware',
             ],
             'TEMPLATE_CONTEXT_PROCESSORS': [
@@ -56,7 +61,7 @@ CONTRIB_CONFIGS = {
         DEFAULT_SETTINGS = {},
         RELATIONSHIPS = [
             OrderingRelationship(
-                'MIDDLEWARE',
+                middleware_key,
                 'django.contrib.messages.middleware.MessageMiddleware',
                 after = [
                     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -68,14 +73,14 @@ CONTRIB_CONFIGS = {
     ),
     'django.contrib.sessions': Autoconfig(
         SETTINGS = {
-            'MIDDLEWARE': [
+            middleware_key: [
                 'django.contrib.sessions.middleware.SessionMiddleware',
             ],
         },
         DEFAULT_SETTINGS = {},
         RELATIONSHIPS = [
             OrderingRelationship(
-                'MIDDLEWARE',
+                middleware_key,
                 'django.contrib.sessions.middleware.SessionMiddleware',
                 after = [
                     'django.middleware.cache.UpdateCacheMiddleware',


### PR DESCRIPTION
I made "MIDDLEWARE_CLASSES" in `contrib/__init__` switch to "MIDDLEWARE" when Django >=1.10 is used so that it is compatible with later versions.

I ran setup.py tests with Python 3.5.2 and Django 1.10.7 and they all passed.