### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,16 +12,16 @@ django-autoconfig
 .. image:: https://landscape.io/github/mikebryant/django-autoconfig/master/landscape.png
    :target: https://landscape.io/github/mikebryant/django-autoconfig/master
    :alt: Code Health Badge
-.. image:: https://pypip.in/v/django-autoconfig/badge.png
+.. image:: https://img.shields.io/pypi/v/django-autoconfig.svg
     :target: https://pypi.python.org/pypi/django-autoconfig/
     :alt: Version Badge
-.. image:: https://pypip.in/d/django-autoconfig/badge.png
+.. image:: https://img.shields.io/pypi/dm/django-autoconfig.svg
     :target: https://pypi.python.org/pypi/django-autoconfig/
     :alt: Downloads Badge
-.. image:: https://pypip.in/wheel/django-autoconfig/badge.png
+.. image:: https://img.shields.io/pypi/wheel/django-autoconfig.svg
     :target: https://pypi.python.org/pypi/django-autoconfig/
     :alt: Wheel Status Badge
-.. image:: https://pypip.in/license/django-autoconfig/badge.png
+.. image:: https://img.shields.io/pypi/l/django-autoconfig.svg
     :target: https://pypi.python.org/pypi/django-autoconfig/
     :alt: License Badge
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-autoconfig))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-autoconfig`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.