### PR TITLE
Support for Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ python:
 - 3.3
 - 3.4
 - 3.5
+- 3.6
 - pypy
 - pypy3.3-5.5-alpha
+- pypy3.5-5.10.1
 env:
 - DJANGO=1.4.15
 - DJANGO=1.6.7
@@ -15,6 +17,7 @@ env:
 - DJANGO=1.9
 - DJANGO=1.10
 - DJANGO=1.11
+- DJANGO=2.0
 install:
 - pip install -q gitversion
 - pip install -q Django==$DJANGO
@@ -36,6 +39,10 @@ matrix:
     env: DJANGO=1.10
   - python: 2.6
     env: DJANGO=1.11
+  - python: 2.6
+    env: DJANGO=2.0
+  - python: 2.7
+    env: DJANGO=2.0
   - python: 3.3
     env: DJANGO=1.4.15
   - python: 3.3
@@ -44,6 +51,8 @@ matrix:
     env: DJANGO=1.10
   - python: 3.3
     env: DJANGO=1.11
+  - python: 3.3
+    env: DJANGO=2.0
   - python: 3.4
     env: DJANGO=1.4.15
   - python: 3.5
@@ -52,6 +61,20 @@ matrix:
     env: DJANGO=1.6.7
   - python: 3.5
     env: DJANGO=1.7
+  - python: 3.6
+    env: DJANGO=1.4.15
+  - python: 3.6
+    env: DJANGO=1.6.7
+  - python: 3.6
+    env: DJANGO=1.7
+  - python: 3.6
+    env: DJANGO=1.8
+  - python: 3.6
+    env: DJANGO=1.9
+  - python: 3.6
+    env: DJANGO=1.10
+  - python: pypy
+    env: DJANGO=2.0
   - python: pypy3.3-5.5-alpha
     env: DJANGO=1.4.15
   - python: pypy3.3-5.5-alpha
@@ -60,6 +83,14 @@ matrix:
     env: DJANGO=1.10
   - python: pypy3.3-5.5-alpha
     env: DJANGO=1.11
+  - python: pypy3.3-5.5-alpha
+    env: DJANGO=2.0
+  - python: pypy3.5-5.10.1
+    env: DJANGO=1.4.15
+  - python: pypy3.5-5.10.1
+    env: DJANGO=1.6.7
+  - python: pypy3.5-5.10.1
+    env: DJANGO=1.7
 deploy:
   provider: pypi
   user: LeaChim
@@ -70,4 +101,4 @@ deploy:
     all_branches: true
     repo: mikebryant/django-autoconfig
     tags: true
-    condition: "$DJANGO = 1.9"
+    condition: "$DJANGO = 1.11"

--- a/django_autoconfig/contrib/admin/urls.py
+++ b/django_autoconfig/contrib/admin/urls.py
@@ -1,3 +1,4 @@
+import django
 from django.conf.urls import include, url
 try:
     from django.conf.urls import patterns
@@ -7,6 +8,13 @@ except ImportError:
 from django.contrib import admin
 
 admin.autodiscover()
-urlpatterns = patterns('',
-    url('', include(admin.site.urls)),
-)
+# admin.site.urls should not be included since Django 1.9 (and breaks since Django 2.0).
+# Additionally, urlpatterns shall be an array since Django 1.8.
+if django.VERSION >= (1, 9):
+    urlpatterns = [
+        url('', admin.site.urls),
+    ]
+else:
+    urlpatterns = patterns('',
+        url('', include(admin.site.urls)),
+    )

--- a/django_autoconfig/tests/app_middleware/autoconfig.py
+++ b/django_autoconfig/tests/app_middleware/autoconfig.py
@@ -1,3 +1,12 @@
-SETTINGS = {
-    'MIDDLEWARE_CLASSES': ['my.middleware'],
-}
+import django
+
+
+# Django 2.0 completely removed MIDDLEWARE_CLASSES. MIDDLEWARE shall be used instead.
+if django.VERSION >= (2, 0):
+    SETTINGS = {
+        'MIDDLEWARE': ['my.middleware'],
+    }
+else:
+    SETTINGS = {
+        'MIDDLEWARE_CLASSES': ['my.middleware'],
+    }

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from django_autoconfig.version import __VERSION__
 import sys
 
 INSTALL_REQUIRES = [
-    'django < 1.12',
+    'django < 2.1',
 ]
 
 if sys.version_info < (2, 7):


### PR DESCRIPTION
I have updated this library to be compatibile with Django 2.0. A few features behaves differently in Django 2.0, so I had to duplicate a few tests: one for Django versions 1.11 and lower and one for Django 2.0 and up.

I have also added Python 3.6 and PyPy3.5-v5.10.1 to the build matrix in `.travis.yml`. All these changes are backwards-compatibile and passes all tests.